### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ yeti-pg-ext is a part of project [Yeti]
 ### install build dependencies
 
 ```sh
-# aptitude install libnanomsg-dev postgresql-server-dev-all
+# aptitude install libnanomsg-dev postgresql-server-dev-all dh-make devscripts
 ```
 
 ### get sources & build


### PR DESCRIPTION
Debina 9, by default, doesn't have `dh-make` and `devscripts` needed for "make deb"-procedure.

Updated README, it might save some time for new users.